### PR TITLE
fix(settings): set number of relations to 100

### DIFF
--- a/sicprod/settings.py
+++ b/sicprod/settings.py
@@ -87,3 +87,12 @@ LOGGING = {
 }
 
 LOG_LIST_NOSTAFF_EXCLUDE_APP_LABELS = ["reversion", "admin", "sessions", "auth"]
+
+APIS_ENTITIES = {
+        "Event": {"relations_per_page": 100},
+        "Function": {"relations_per_page": 100},
+        "Institution": {"relations_per_page": 100},
+        "Person": {"relations_per_page": 100},
+        "Place": {"relations_per_page": 100},
+        "Salary": {"relations_per_page": 100},
+        }


### PR DESCRIPTION
This setting still uses the old APIS_ENTITIES settings system.
