### PR TITLE
feat(deps): add django-auditlog

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -5,6 +5,8 @@ from apis_core.core.models import LegacyDateMixin
 from apis_core.collections.models import SkosCollection, SkosCollectionContentObject
 from apis_core.history.models import VersionMixin
 
+from auditlog.registry import auditlog
+
 
 class LegacyStuffMixin(models.Model):
     review = review = models.BooleanField(default=False, help_text="Should be set to True, if the data record holds up quality standards.")
@@ -99,3 +101,11 @@ class Salary(VersionMixin, LegacyStuffMixin, LegacyDateMixin, AbstractEntity):
     typ = models.CharField(max_length=9, choices=TYP_CHOICES, blank=True, verbose_name = "Typ", help_text = "Art des Gehalts.")
     REPETITIONTYPE_CHOICES = (("einfach", "einfach"), ("wiederholend", "wiederholend"), )
     repetitionType = models.CharField(max_length=12, choices=REPETITIONTYPE_CHOICES, blank=True, verbose_name = "Typ Wiederholungen", help_text = "Typ des Gehalts.")
+
+
+auditlog.register(Person, serialize_data=True)
+auditlog.register(Function, serialize_data=True)
+auditlog.register(Place, serialize_data=True)
+auditlog.register(Institution, serialize_data=True)
+auditlog.register(Event, serialize_data=True)
+auditlog.register(Salary, serialize_data=True)

--- a/apis_ontology/templates/auditlog/logentry_list.html
+++ b/apis_ontology/templates/auditlog/logentry_list.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container">
+{% if object_list %}
+<ul>
+  {% for object in object_list %}
+    <li>{{ object.timestamp }} <a href={% url "apis_core:generic:detail" object.content_type object.object_id %}>{{ object }}</a>
+    {% if object.action != 2 %}:
+      {% for change, values in object.changes_dict.items %}<b>{{ change }}</b>
+        {% if values.operation and values.objects %}
+          {{ values.operation }} {{ values.objects|join:", " }}
+        {% else %}
+          "{{ values.0|truncatechars:32 }}" -> "{{ values.1|truncatechars:32 }}"
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+</div>
+{% endblock content %}

--- a/apis_ontology/views.py
+++ b/apis_ontology/views.py
@@ -1,0 +1,8 @@
+from django.views.generic.list import ListView
+from django.contrib.auth.mixins import LoginRequiredMixin
+from auditlog.models import LogEntry
+
+
+class UserAuditLog(LoginRequiredMixin, ListView):
+    def get_queryset(self, *args, **kwargs):
+        return LogEntry.objects.filter(actor=self.request.user)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ apis-acdhch-default-settings = "1.0.0"
 psycopg2 = "^2.9.6"
 django-acdhch-functions = "^0.1.2"
 django-cors-headers = "^4"
+django-auditlog = "^3.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/sicprod/settings.py
+++ b/sicprod/settings.py
@@ -27,6 +27,7 @@ INSTALLED_APPS = ["django_acdhch_functions"] + INSTALLED_APPS
 INSTALLED_APPS += ["apis_core.collections"]
 INSTALLED_APPS += ["apis_core.history"]
 INSTALLED_APPS += ["simple_history"]
+INSTALLED_APPS += ["auditlog"]
 PROJECT_METADATA = {
         "matomo_url": "https://matomo.acdh.oeaw.ac.at/",
         "matomo_id": 242
@@ -107,3 +108,5 @@ MIDDLEWARE = ["corsheaders.middleware.CorsMiddleware"] + MIDDLEWARE
 CORS_ALLOWED_ORIGINS = ["http://localhost:3000", "https://sicprod-frontend.acdh-ch-dev.oeaw.ac.at"]
 
 SPECTACULAR_SETTINGS["DEFAULT_GENERATOR_CLASS"] = 'apis_ontology.generators.SicprodCustomSchemaGenerator'
+
+MIDDLEWARE += ['auditlog.middleware.AuditlogMiddleware']

--- a/sicprod/urls.py
+++ b/sicprod/urls.py
@@ -3,6 +3,7 @@ from django.urls import path, include
 from rest_framework import routers
 
 from apis_ontology.api_views import ListEntityRelations, SicprodModelViewSet
+from apis_ontology.views import UserAuditLog
 
 urlpatterns += [path("", include("django_acdhch_functions.urls")),]
 
@@ -13,3 +14,5 @@ urlpatterns += [path("apis/api/<contenttype:contenttype>/<int:pk>/relations", Li
 router = routers.DefaultRouter()
 router.register(r"", SicprodModelViewSet, basename="genericmodelapi")
 urlpatterns.insert(0, path("apis/api/<contenttype:contenttype>/", include(router.urls)))
+
+urlpatterns += [path("auditlog", UserAuditLog.as_view()),]


### PR DESCRIPTION
This adds the django auditlog module and enables it for our ontology
models. It also adds the middleware, so that we have access to the
actor.
We also create an endpoint `/auditlog` that lists the changes made by
the user requesting it.
