### PR TITLE
fix(api/swagger): add the references as array to the detail endpoints

### DIFF
--- a/apis_ontology/serializers.py
+++ b/apis_ontology/serializers.py
@@ -85,8 +85,6 @@ class SicprodSerializer(GenericHyperlinkedModelSerializer):
     def get_fields(self):
         fields = super().get_fields()
         fields["relation_types"] = serializers.SerializerMethodField(method_name="get_relation_types")
-        if self.context["view"].action == "retrieve":
-            fields["references"] = serializers.SerializerMethodField(method_name="get_references")
         return fields
 
     def get_relation_types(self, obj) -> list[str]:
@@ -101,37 +99,78 @@ class SicprodSerializer(GenericHyperlinkedModelSerializer):
             relations.add(reltype)
         return relations
 
+
+class ReferencesMixin(serializers.Serializer):
+    references = serializers.SerializerMethodField(method_name="get_references")
+
+    @extend_schema_field(ReferenceSerializer(many=True))
     def get_references(self, obj):
         ct = ContentType.objects.get_for_model(obj)
         references = Reference.objects.filter(content_type=ct, object_id=obj.id)
         return ReferenceSerializer(references, many=True).data
 
 
-class EventSerializer(SicprodSerializer):
+class EventListSerializer(SicprodSerializer, serializers.ListSerializer):
     class Meta:
         fields = ["id", "name", "start_date_written", "end_date_written", "type"]
 
 
-class FunctionSerializer(SicprodSerializer):
+class EventSerializer(ReferencesMixin, SicprodSerializer):
+    class Meta:
+        fields = ["id", "name", "start_date_written", "end_date_written", "type", "references"]
+        list_serializer_class = EventListSerializer
+
+
+class FunctionListSerializer(SicprodSerializer, serializers.ListSerializer):
     class Meta:
         fields = ["id", "name", "start_date_written", "end_date_written", "alternative_label"]
 
 
-class InstitutionSerializer(SicprodSerializer):
+class FunctionSerializer(ReferencesMixin, SicprodSerializer):
+    class Meta:
+        fields = ["id", "name", "start_date_written", "end_date_written", "alternative_label", "references"]
+        list_serializer_class = FunctionListSerializer
+
+
+class InstitutionListSerializer(SicprodSerializer, serializers.ListSerializer):
     class Meta:
         fields = ["id", "name", "start_date_written", "end_date_written", "type", "alternative_label"]
 
 
-class PersonSerializer(SicprodSerializer):
+class InstitutionSerializer(ReferencesMixin, SicprodSerializer):
+    class Meta:
+        fields = ["id", "name", "start_date_written", "end_date_written", "type", "alternative_label", "references"]
+        list_serializer_class = InstitutionListSerializer
+
+
+class PersonListSerializer(SicprodSerializer, serializers.ListSerializer):
     class Meta:
         fields = ["id", "url", "name", "start_date_written", "end_date_written", "status", "first_name", "gender", "alternative_label"]
 
 
-class PlaceSerializer(SicprodSerializer):
+class PersonSerializer(ReferencesMixin, SicprodSerializer):
+    class Meta:
+        fields = ["id", "url", "name", "start_date_written", "end_date_written", "status", "first_name", "gender", "alternative_label", "references"]
+        list_serializer_class = PersonListSerializer
+
+
+class PlaceListSerializer(SicprodSerializer, serializers.ListSerializer):
     class Meta:
         fields = ["id", "name", "start_date_written", "end_date_written", "type", "longitude", "latitude", "alternative_label"]
 
 
-class SalarySerializer(SicprodSerializer):
+class PlaceSerializer(ReferencesMixin, SicprodSerializer):
+    class Meta:
+        fields = ["id", "name", "start_date_written", "end_date_written", "type", "longitude", "latitude", "alternative_label", "references"]
+        list_serializer_class = PlaceListSerializer
+
+
+class SalaryListSerializer(SicprodSerializer, serializers.ListSerializer):
     class Meta:
         fields = ["id", "name", "start_date_written", "end_date_written", "typ", "repetitionType"]
+
+
+class SalarySerializer(ReferencesMixin, SicprodSerializer):
+    class Meta:
+        fields = ["id", "name", "start_date_written", "end_date_written", "typ", "repetitionType", "references"]
+        list_serializer_class = SalaryListSerializer


### PR DESCRIPTION
The swagger generator uses the serializer to generate the output, but it
only looks at the `list` serialization by default. The `references` in
the SicprodSerializer where only added for the `retrieve` action,
though.
We can refactor that and use a separate ListSerializer for all the
classes, this differentiation is then also picked up the the swagger
generator. To make things a bit easier to read, we move the `references`
field setup to a `ReferencesMixin` which then gets reused by the
individual serializers.
