### PR TITLE
chore(deps): bump apis-core to v0.24.0 and adapt code

### DIFF
--- a/apis_ontology/filtersets.py
+++ b/apis_ontology/filtersets.py
@@ -79,11 +79,6 @@ class LegacyStuffMixinFilterSet(AbstractEntityFilterSet):
 
 
 class SalaryFilterSet(LegacyStuffMixinFilterSet):
-    search = django_filters.CharFilter(method="search_salary", label="Search")
-
-    def search_salary(self, queryset, name, value):
-        return queryset.filter(name__icontains=value)
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.filters["typ"].method = filter_empty_string
@@ -92,11 +87,6 @@ class SalaryFilterSet(LegacyStuffMixinFilterSet):
 
 
 class FunctionFilterSet(LegacyStuffMixinFilterSet):
-    search = django_filters.CharFilter(method="search_function", label="Search")
-
-    def search_function(self, queryset, name, value):
-        return queryset.filter(Q(name__icontains=value)|Q(alternative_label__icontains=value))
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.filters["name"].method = name_alternative_name_filter
@@ -104,11 +94,6 @@ class FunctionFilterSet(LegacyStuffMixinFilterSet):
 
 
 class PlaceFilterSet(LegacyStuffMixinFilterSet):
-    search = django_filters.CharFilter(method="search_place", label="Search")
-
-    def search_place(self, queryset, name, value):
-        return queryset.filter(Q(name__icontains=value)|Q(alternative_label__icontains=value))
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.filters["type"].method = filter_empty_string
@@ -121,11 +106,6 @@ PERSON_FILTERS_EXCLUDE.remove("status")
 
 
 class PersonFilterSet(LegacyStuffMixinFilterSet):
-    search = django_filters.CharFilter(method="search_person", label="Search")
-
-    def search_person(self, queryset, name, value):
-        return queryset.filter(Q(first_name__icontains=value)|Q(name__icontains=value)|Q(alternative_label__icontains=value))
-
     class Meta(LegacyStuffMixinFilterSet.Meta):
         exclude = PERSON_FILTERS_EXCLUDE
 
@@ -139,21 +119,9 @@ class PersonFilterSet(LegacyStuffMixinFilterSet):
 
 
 class InstitutionFilterSet(LegacyStuffMixinFilterSet):
-    search = django_filters.CharFilter(method="search_institution", label="Search")
-
-    def search_institution(self, queryset, name, value):
-        return queryset.filter(Q(name__icontains=value)|Q(alternative_label__icontains=value))
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.filters["name"].method = name_alternative_name_filter
-
-
-class EventFilterSet(LegacyStuffMixinFilterSet):
-    search = django_filters.CharFilter(method="search_event", label="Search")
-
-    def search_event(self, queryset, name, value):
-        return queryset.filter(Q(name__icontains=value)|Q(alternative_label__icontains=value))
 
 
 # Those are simply there to remove the `metadata` which is a JSONField and makes the django-filter throw up
@@ -242,5 +210,5 @@ class InstitutionApiFilterSet(FacetFilterSetMixin, InstitutionFilterSet):
     pass
 
 
-class EventApiFilterSet(FacetFilterSetMixin, EventFilterSet):
+class EventApiFilterSet(FacetFilterSetMixin, LegacyStuffMixinFilterSet):
     pass

--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -36,6 +36,7 @@ class Person(VersionMixin, LegacyStuffMixin, LegacyDateMixin, AbstractEntity):
     Person, eine Subklasse von crm:E21_Person.
     Generated from model xml
     """
+    _default_search_fields = ["first_name", "name", "alternative_label"]
     first_name = models.CharField(max_length=1024, blank=True, null=True, verbose_name = "Vorname", help_text = "Vorname der Person.")
     name = models.CharField(max_length=255, verbose_name="Name", blank=True)
     GENDER_CHOICES = (("männlich", "männlich"), ("weiblich", "weiblich"), ("unbekannt", "unbekannt"), )
@@ -54,6 +55,7 @@ class Function(VersionMixin, LegacyStuffMixin, LegacyDateMixin, AbstractEntity):
     Eine Funktion kann von einer Person an einer Institution oder einem Hof ausgeübt werden kann.
     Generated from model xml
     """
+    _default_search_fields = ["name", "alternative_label"]
     name = models.CharField(max_length=255, verbose_name="Name", blank=True)
     alternative_label = models.TextField(blank=True, null=True, verbose_name = "Alternativer Name", help_text = "Andere Namen für die Funktion.")
 
@@ -66,6 +68,7 @@ class Place(VersionMixin, LegacyStuffMixin, LegacyDateMixin, AbstractEntity):
     Orte in SiCProD, Subklasse von crm:E53_Place.
     Generated from model xml
     """
+    _default_search_fields = ["name", "alternative_label"]
     name = models.CharField(max_length=255, verbose_name="Name", blank=True)
     alternative_label = models.TextField(blank=True, null=True, verbose_name = "Alternativer Name", help_text = "Alternativer Name für einen Ort.")
     TYPE_CHOICES = (("Stadt", "Stadt"), ("Dorf/Nachbarschaft/Gemein/Siedlung/Weiler", "Dorf/Nachbarschaft/Gemein/Siedlung/Weiler"), ("Burg/Schloss", "Burg/Schloss"), ("Land/Herrschaftskomplex", "Land/Herrschaftskomplex"), ("Landschaft/Region", "Landschaft/Region"), ("Lehen", "Lehen"), ("Haus/Hof", "Haus/Hof"), ("Gericht", "Gericht"), ("Kloster", "Kloster"), ("Gewässer", "Gewässer"), ("Grundherrschaft", "Grundherrschaft"), ("Hofmark", "Hofmark"), ("Tal", "Tal"), ("Berg", "Berg"), ("Bergrevier", "Bergrevier"), ("Pflege", "Pflege"), ("(Land-)Vogtei", "(Land-)Vogtei"), ("Propstei", "Propstei"), )
@@ -82,6 +85,7 @@ class Institution(VersionMixin, LegacyStuffMixin, LegacyDateMixin, AbstractEntit
     SiCProD Institution, Subklasse von crm:E74_Group. Wird für alle Institutionen benutzt die kein Hof sind
     Generated from model xml
     """
+    _default_search_fields = ["name", "alternative_label"]
     name = models.CharField(max_length=255, verbose_name="Name", blank=True)
     alternative_label = models.TextField(blank=True, null=True, verbose_name = "Alternativer Name", help_text = "Alternativer Name der Institution.")
     TYPE_CHOICES = (("Kanzlei", "Kanzlei"), ("Hofkapelle", "Hofkapelle"), ("Küche", "Küche"), ("(Dom-)Kapitel", "(Dom-)Kapitel"), ("Universität", "Universität"), ("Kloster", "Kloster"), ("Frauenzimmer", "Frauenzimmer"), ("Bistum", "Bistum"), ("Pfarrei", "Pfarrei"), )
@@ -96,6 +100,7 @@ class Event(VersionMixin, LegacyStuffMixin, LegacyDateMixin, AbstractEntity):
     SiCProD Ereignis, Subklasse von crm:E5_Event.
     Generated from model xml
     """
+    _default_search_fields = ["name", "alternative_label"]
     name = models.CharField(max_length=255, verbose_name="Name", blank=True)
     alternative_label = models.TextField(blank=True, null=True, verbose_name = "Alternativer Name", help_text = "Alternativer Name.")
     TYPE_CHOICES = (("Hochzeit", "Hochzeit"), ("Landtag", "Landtag"), ("Fest/Turnier", "Fest/Turnier"), ("Schlacht", "Schlacht"), ("Gesandtschaft/Reise", "Gesandtschaft/Reise"), ("Taufe", "Taufe"), ("Amtseinsetzung", "Amtseinsetzung"), ("Reichstag", "Reichstag"), )
@@ -110,6 +115,7 @@ class Salary(VersionMixin, LegacyStuffMixin, LegacyDateMixin, AbstractEntity):
     Ein Gehalt ist die Menge an Geld die eine Person als Gegenleistung erhalten hat. Das Gehalt muss keine wiederkehrende Zahlung sein.
     Generated from model xml
     """
+    _default_search_fields = ["name"]
     name = models.CharField(max_length=255, verbose_name="Name", blank=True)
     TYP_CHOICES = (("Sold", "Sold"), ("Zehrung", "Zehrung"), ("Provision", "Provision"), ("Kredit", "Kredit"), ("Sonstiges", "Sonstiges"), ("Burghut", "Burghut"), ("Botenlohn", "Botenlohn"), )
     typ = models.CharField(max_length=9, choices=TYP_CHOICES, blank=True, verbose_name = "Typ", help_text = "Art des Gehalts.")

--- a/apis_ontology/templates/generic/partials/object_table.html
+++ b/apis_ontology/templates/generic/partials/object_table.html
@@ -20,10 +20,6 @@
     <th>References</th>
     <td>{% link_to_reference_on obj=object modal=True %}</td>
   </tr>
-  <tr>
-    <th>URIs</th>
-    <td>{{ object.uri_set.all | join:", " | urlize}}</td>
-  </tr>
   {% endblock objecttable %}
 </table>
 <table class="table table-hover table-bordered">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "apis_ontology"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-apis-core = { git = "https://github.com/acdh-oeaw/apis-core-rdf.git", tag = "v0.23.2" }
+apis-core = { git = "https://github.com/acdh-oeaw/apis-core-rdf.git", tag = "v0.24.0" }
 apis-bibsonomy = "0.9.1"
 apis-acdhch-default-settings = "1.0.0"
 psycopg2 = "^2.9.6"


### PR DESCRIPTION
The new apis version introduces a default search filter, which does
exactly what we did with our custom search filter, so we use that
instead.
We also update the object template, because upstreams template now also
contains the URI of the object.
