### PR TITLE
chore(deps): install and use django_grouper

### DIFF
--- a/apis_ontology/templates/django_grouper/grouper.html
+++ b/apis_ontology/templates/django_grouper/grouper.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block content %}
+    <div class="container mt-3">
+        <ul>
+            {% for group, ids in groups.items %}
+                <li>
+                    {{ group }}
+		    <p>
+                      {{ ids|length }} occurences
+		      {% for id in ids %}
+		      <a href="{% url "apis_core:apis_entities:generic_entities_detail_view" content_type.model id %}">{{ id }}</a>,
+		      {% endfor %}
+		    </p>
+                </li>
+                <hr />
+            {% endfor %}
+        </ul>
+    </div>
+{% endblock content %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ django-acdhch-functions = "^0.1.4"
 django-cors-headers = "^4"
 django-auditlog = "^3.0.0"
 roman = "^4.2"
+django-grouper = "^0.2.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/sicprod/settings.py
+++ b/sicprod/settings.py
@@ -28,6 +28,7 @@ INSTALLED_APPS += ["apis_core.collections"]
 INSTALLED_APPS += ["apis_core.history"]
 INSTALLED_APPS += ["simple_history"]
 INSTALLED_APPS += ["auditlog"]
+INSTALLED_APPS += ["django_grouper"]
 PROJECT_METADATA = {
         "matomo_url": "https://matomo.acdh.oeaw.ac.at/",
         "matomo_id": 242

--- a/sicprod/urls.py
+++ b/sicprod/urls.py
@@ -20,3 +20,5 @@ urlpatterns += [path("auditlog", UserAuditLog.as_view()),]
 urlpatterns += [path("apis/api/network", Network.as_view(), name="network")]
 
 urlpatterns += [path("apis/failingreferences", ReferenceScanFail.as_view(), name="referencescanfail")]
+
+urlpatterns += [path("", include("django_grouper.urls"))]


### PR DESCRIPTION
We install django grouper, add it to the list of INSTALLED_APPS and add
the routes the `urls.py`.
We override the default grouper.html template shipped with
django_grouper, because our base template is located somewhere else and
we don't use the merge overview.
