### PR TITLE
birger/drop functions from settings

### DIFF
--- a/sicprod/settings.py
+++ b/sicprod/settings.py
@@ -23,7 +23,6 @@ LANGUAGE_CODE = "de"
 INSTALLED_APPS += ["apis_bibsonomy"]
 INSTALLED_APPS.remove("apis_ontology")
 INSTALLED_APPS = ["apis_ontology"] + INSTALLED_APPS
-INSTALLED_APPS = ["django_acdhch_functions"] + INSTALLED_APPS
 INSTALLED_APPS += ["apis_core.collections"]
 INSTALLED_APPS += ["apis_core.history"]
 INSTALLED_APPS += ["simple_history"]


### PR DESCRIPTION
- chore(deps): drop django-acdhch-functions dependency
- fix(settings): drop functions from the INSTALLED_APPS
