### PR TITLE
chore(deps): bump apis-core-rdf to v0.29.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "apis_ontology"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-apis-core = { git = "https://github.com/acdh-oeaw/apis-core-rdf.git", tag = "v0.28.0" }
+apis-core-rdf = "0.29.0"
 apis-bibsonomy = "0.11.0"
 apis-acdhch-default-settings = "1.4.0"
 psycopg2 = "^2.9.6"


### PR DESCRIPTION
and use pypi release instead of git tag
