### PR TITLE
Revert "build: add robots.txt to nginx ingress annotations"

### DIFF
--- a/.github/auto-deploy-values.yaml
+++ b/.github/auto-deploy-values.yaml
@@ -27,10 +27,6 @@ ingress:
   path: "/"
   annotations:
     kubernetes.io/ingressClassName: "nginx"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      location /robots.txt {
-        return 200 "User-agent: *\nDisallow: /\n";
-      }
 
 livenessProbe:
   path: "/" #"${{ inputs.APP_ROOT }}"


### PR DESCRIPTION
This reverts commit 25c9dd3ba2f8c9d1b0c9a9811542b250e9112c3e.

We are not allowed to use the snipped directive .. :(
